### PR TITLE
fix out of order data for counter layouts

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -119,6 +119,7 @@ def counter_layout_pipeline(sensor_, url_Open_Data_Katalog, type_):
 
     load_params = {'resource_id': 'ebe5e78c-a99f-4607-bedc-051f33d75318',
                    'fields': ', '.join(fields),
+                   'sort': 'DATUM asc',
                    'filters': json.dumps(filters),
                    'limit': 32000,
                    }


### PR DESCRIPTION
Fixes out of order data for counter layouts by adding a sort parameter on ckan-datastore request.

Closes #81 