### PR TITLE
Add include total parameter

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -122,6 +122,7 @@ def counter_layout_pipeline(sensor_, url_Open_Data_Katalog, type_):
                    'sort': 'DATUM asc',
                    'filters': json.dumps(filters),
                    'limit': 32000,
+                   'include_total': False,
                    }
 
     response = requests.get(url_Open_Data_Katalog, params=load_params)
@@ -220,7 +221,8 @@ def air_layout_pipeline(sensor, url_Open_Data_Katalog):
     load_params = {'resource_id': '4466ec4a-b215-4134-8973-2f360e53c33d',
                    "sort": 'Datum desc',
                    "limit": 9,
-                   "filters": json.dumps(filters)
+                   "filters": json.dumps(filters),
+                   'include_total': False
                    }
 
     response = requests.get(url_Open_Data_Katalog, params=load_params)

--- a/api/index.py
+++ b/api/index.py
@@ -122,7 +122,7 @@ def counter_layout_pipeline(sensor_, url_Open_Data_Katalog, type_):
                    'sort': 'DATUM asc',
                    'filters': json.dumps(filters),
                    'limit': 32000,
-                   'include_total': False,
+                   'include_total': False
                    }
 
     response = requests.get(url_Open_Data_Katalog, params=load_params)


### PR DESCRIPTION
Behind the datastore-API is a Postgres-DB to which queries of the total row-count are cost-intensive.
As the requests are filtered and limited, I assume that the total-count is not needed in the result.
See here for more information: https://ckan.org/blog/faster-datastore-in-ckan-2-7